### PR TITLE
use sigilles parameter with |

### DIFF
--- a/lib/Test/Mock.pm
+++ b/lib/Test/Mock.pm
@@ -52,8 +52,8 @@ module Test::Mock {
             last unless $p.^parents(:local);
             for $p.^methods(:local) -> $m {
                 unless %already-seen{$m.name} {
-                    $mocker.HOW.add_method($mocker, $m.name, method (|$c) {
-                        self.'!mock-log'().log-method-call($m.name, $c);
+                    $mocker.HOW.add_method($mocker, $m.name, method (|c) {
+                        self.'!mock-log'().log-method-call($m.name, c);
                         %returning{$m.name} ~~ Iterable || %returning{$m.name} ~~ Parcel ??
                             @(%returning{$m.name}) !!
                             %returning{$m.name}


### PR DESCRIPTION
avoids a compile-time warning
